### PR TITLE
Reduce type castings with generics

### DIFF
--- a/src/LLL.ComputedExpression.EFCore/DbContextExtensions.cs
+++ b/src/LLL.ComputedExpression.EFCore/DbContextExtensions.cs
@@ -5,7 +5,6 @@ using LLL.ComputedExpression.EFCore.Internal;
 using LLL.ComputedExpression.Incremental;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Query;
 
 namespace LLL.ComputedExpression.EFCore;
 
@@ -21,73 +20,33 @@ public static class DbContextExtensions
         return optionsBuilder;
     }
 
-    public static IAffectedEntitiesProvider? GetAffectedEntitiesProvider(this DbContext dbContext, LambdaExpression computedExpression)
-    {
-        var analyzer = GetComputedExpressionAnalyzer(dbContext);
-
-        var cache = dbContext.GetService<IConcurrentCreationCache>();
-
-        var cacheKey = (
-            Analyzer: analyzer,
-            Puropse: "AffectedEntities",
-            ExpressionKey: new ExpressionCacheKey(computedExpression, ExpressionEqualityComparer.Instance)
-        );
-
-        return cache.GetOrCreate(
-            cacheKey,
-            static (k) => k.Analyzer.CreateAffectedEntitiesProvider((LambdaExpression)k.ExpressionKey.Expression));
-    }
-
-    public static async Task<IReadOnlyCollection<TEntity>> GetAffectedEntitiesAsync<TEntity, P>(
-        this DbContext dbContext, Expression<Func<TEntity, P>> computedExpression)
+    public static async Task<IReadOnlyCollection<TEntity>> GetAffectedEntitiesAsync<TEntity, TValue>(
+        this DbContext dbContext, Expression<Func<TEntity, TValue>> computedExpression)
     {
         var affectedEntitiesProvider = dbContext.GetAffectedEntitiesProvider(computedExpression);
         if (affectedEntitiesProvider is null)
             return [];
 
-        var affectedEntities = await affectedEntitiesProvider.GetAffectedEntitiesAsync(new EFCoreComputedInput(dbContext));
-        return affectedEntities.OfType<TEntity>().ToArray();
+        return await affectedEntitiesProvider.GetAffectedEntitiesAsync(new EFCoreComputedInput(dbContext));
     }
 
-    public static IChangesProvider? GetChangesProviderAsync<TEntity, P>(
-        this DbContext dbContext, Expression<Func<TEntity, P>> computedExpression)
-        where TEntity : notnull
-    {
-        var analyzer = GetComputedExpressionAnalyzer(dbContext);
-
-        var cache = dbContext.GetService<IConcurrentCreationCache>();
-
-        var cacheKey = (
-            Analyzer: analyzer,
-            Purpose: "ChangesProvider",
-            ExpressionKey: new ExpressionCacheKey(computedExpression, ExpressionEqualityComparer.Instance)
-        );
-
-        return cache.GetOrCreate(
-            cacheKey,
-            static (k) => k.Analyzer.CreateChangesProvider((LambdaExpression)k.ExpressionKey.Expression));
-    }
-
-    public static async Task<IReadOnlyDictionary<TEntity, (P? originalValue, P? newValue)>> GetChangesAsync<TEntity, P>(
-        this DbContext dbContext, Expression<Func<TEntity, P>> computedExpression)
+    public static async Task<IReadOnlyDictionary<TEntity, (TValue? originalValue, TValue? newValue)>> GetChangesAsync<TEntity, TValue>(
+        this DbContext dbContext, Expression<Func<TEntity, TValue?>> computedExpression)
         where TEntity : notnull
     {
         var changesProvider = dbContext.GetChangesProviderAsync(computedExpression);
         if (changesProvider is null)
-            return ImmutableDictionary<TEntity, (P?, P?)>.Empty;
+            return ImmutableDictionary<TEntity, (TValue?, TValue?)>.Empty;
 
-        var changes = await changesProvider.GetChangesAsync(new EFCoreComputedInput(dbContext));
-        return changes.ToDictionary(
-            kv => (TEntity)kv.Key,
-            kv => ((P?)kv.Value.OriginalValue, (P?)kv.Value.NewValue));
+        return await changesProvider.GetChangesAsync(new EFCoreComputedInput(dbContext));
     }
 
-    public static async Task<IReadOnlyDictionary<TEntity, V>> GetIncrementalChanges<TEntity, V>(
-        this DbContext dbContext, IIncrementalComputed<TEntity, V> incrementalComputed)
+    public static async Task<IReadOnlyDictionary<TEntity, TValue>> GetIncrementalChanges<TEntity, TValue>(
+        this DbContext dbContext, IIncrementalComputed<TEntity, TValue> incrementalComputed)
         where TEntity : notnull
-        where V : notnull
+        where TValue : notnull
     {
-        var analyzer = GetComputedExpressionAnalyzer(dbContext);
+        var analyzer = dbContext.GetComputedExpressionAnalyzer();
 
         var cache = dbContext.GetService<IConcurrentCreationCache>();
 
@@ -99,13 +58,12 @@ public static class DbContextExtensions
 
         var incrementalChangeProvider = cache.GetOrCreate(
             cacheKey,
-            static (k) => k.analyzer.CreateIncrementalChangesProvider(
+            static (k) => (IIncrementalChangesProvider<IEFCoreComputedInput, TEntity, TValue>)k.analyzer.CreateIncrementalChangesProvider(
                 k.incrementalComputed));
 
         var input = new EFCoreComputedInput(dbContext);
 
-        var changes = await incrementalChangeProvider.GetIncrementalChangesAsync(input);
-        return changes.ToDictionary(kv => (TEntity)kv.Key, kv => (V)kv.Value!);
+        return await incrementalChangeProvider.GetIncrementalChangesAsync(input);
     }
 
     public static async Task<int> UpdateComputedsAsync(this DbContext dbContext)
@@ -127,13 +85,5 @@ public static class DbContextExtensions
                 break;
         }
         return totalChanges;
-    }
-
-    private static IComputedExpressionAnalyzer GetComputedExpressionAnalyzer(DbContext dbContext)
-    {
-        if (dbContext.Model.FindRuntimeAnnotation(ComputedAnnotationNames.ExpressionAnalyzer)?.Value is not IComputedExpressionAnalyzer analyzer)
-            throw new Exception($"Cannot find {ComputedAnnotationNames.ExpressionAnalyzer} for model");
-
-        return analyzer;
     }
 }

--- a/src/LLL.ComputedExpression.EFCore/Internal/ComputedRuntimeConvention.cs
+++ b/src/LLL.ComputedExpression.EFCore/Internal/ComputedRuntimeConvention.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
 using LLL.ComputedExpression;
 using LLL.ComputedExpression.EFCore.Internal;
 using LLL.ComputedExpression.Incremental;
@@ -127,7 +126,7 @@ class ComputedRuntimeConvention(Func<IModel, IComputedExpressionAnalyzer> comput
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"Invalid computed expression for '{property.DeclaringType.ShortName()}.{property.Name}': {ex.Message}");
+            throw new InvalidOperationException($"Invalid computed expression for '{property.DeclaringType.ShortName()}.{property.Name}': {ex.Message}", ex);
         }
     }
 }

--- a/src/LLL.ComputedExpression.EFCore/Internal/DbContextExtensions.cs
+++ b/src/LLL.ComputedExpression.EFCore/Internal/DbContextExtensions.cs
@@ -1,0 +1,70 @@
+using System.Linq.Expressions;
+using LLL.ComputedExpression.Caching;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Query;
+
+namespace LLL.ComputedExpression.EFCore.Internal;
+
+public static class DbContextExtensions
+{
+    public static IAffectedEntitiesProvider? GetAffectedEntitiesProvider(this DbContext dbContext, LambdaExpression computedExpression)
+    {
+        var analyzer = GetComputedExpressionAnalyzer(dbContext);
+
+        var cache = dbContext.GetService<IConcurrentCreationCache>();
+
+        var cacheKey = (
+            Analyzer: analyzer,
+            Puropse: "AffectedEntities",
+            ExpressionKey: new ExpressionCacheKey(computedExpression, ExpressionEqualityComparer.Instance)
+        );
+
+        return cache.GetOrCreate(
+            cacheKey,
+            static (k) => k.Analyzer.CreateAffectedEntitiesProvider((LambdaExpression)k.ExpressionKey.Expression));
+    }
+
+    public static IAffectedEntitiesProvider<IEFCoreComputedInput, TEntity>? GetAffectedEntitiesProvider<TEntity, TValue>(this DbContext dbContext, Expression<Func<TEntity, TValue>> computedExpression)
+    {
+        var affectedEntitiesProvider = dbContext.GetAffectedEntitiesProvider((LambdaExpression)computedExpression)!;
+        if (affectedEntitiesProvider is null)
+            return null;
+        return (IAffectedEntitiesProvider<IEFCoreComputedInput, TEntity>)affectedEntitiesProvider;
+    }
+
+    public static IChangesProvider? GetChangesProviderAsync(this DbContext dbContext, LambdaExpression computedExpression)
+    {
+        var analyzer = GetComputedExpressionAnalyzer(dbContext);
+
+        var cache = dbContext.GetService<IConcurrentCreationCache>();
+
+        var cacheKey = (
+            Analyzer: analyzer,
+            Purpose: "ChangesProvider",
+            ExpressionKey: new ExpressionCacheKey(computedExpression, ExpressionEqualityComparer.Instance)
+        );
+
+        return cache.GetOrCreate(
+            cacheKey,
+            static (k) => k.Analyzer.CreateChangesProvider((LambdaExpression)k.ExpressionKey.Expression));
+    }
+
+    public static IChangesProvider<IEFCoreComputedInput, TEntity, TValue>? GetChangesProviderAsync<TEntity, TValue>(
+        this DbContext dbContext, Expression<Func<TEntity, TValue>> computedExpression)
+        where TEntity : notnull
+    {
+        var changesProvider = dbContext.GetChangesProviderAsync((LambdaExpression)computedExpression);
+        if (changesProvider is null)
+            return null;
+        return (IChangesProvider<IEFCoreComputedInput, TEntity, TValue>)changesProvider;
+    }
+
+    public static IComputedExpressionAnalyzer GetComputedExpressionAnalyzer(this DbContext dbContext)
+    {
+        if (dbContext.Model.FindRuntimeAnnotation(ComputedAnnotationNames.ExpressionAnalyzer)?.Value is not IComputedExpressionAnalyzer analyzer)
+            throw new Exception($"Cannot find {ComputedAnnotationNames.ExpressionAnalyzer} for model");
+
+        return analyzer;
+    }
+}

--- a/src/LLL.ComputedExpression.EFCore/Internal/EFCoreEntityNavigation.cs
+++ b/src/LLL.ComputedExpression.EFCore/Internal/EFCoreEntityNavigation.cs
@@ -4,27 +4,30 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace LLL.ComputedExpression.EFCore.Internal;
 
-public class EFCoreEntityNavigation(
+public class EFCoreEntityNavigation<TSourceEntity, TTargetEntity>(
     INavigation navigation
-) : IEntityNavigation<IEFCoreComputedInput>
+) : IEntityNavigation<IEFCoreComputedInput, TSourceEntity, TTargetEntity>
 {
     public virtual string Name => navigation.Name;
+    public Type TargetEntityType => navigation.TargetEntityType.ClrType;
     public virtual bool IsCollection => navigation.IsCollection;
 
-    public virtual IEntityNavigation<IEFCoreComputedInput> GetInverse()
+    public virtual IEntityNavigation<IEFCoreComputedInput, TTargetEntity, TSourceEntity> GetInverse()
     {
         var inverse = navigation.Inverse
             ?? throw new InvalidOperationException($"No inverse for navigation '{navigation.DeclaringType.ShortName()}.{navigation.Name}'");
 
-        return new EFCoreEntityNavigation(inverse);
+        return new EFCoreEntityNavigation<TTargetEntity, TSourceEntity>(inverse);
     }
 
-    public virtual async Task<IReadOnlyCollection<object>> LoadOriginalAsync(IEFCoreComputedInput input, IReadOnlyCollection<object> targetEntities)
+    public virtual async Task<IReadOnlyCollection<TTargetEntity>> LoadOriginalAsync(
+        IEFCoreComputedInput input,
+        IReadOnlyCollection<TSourceEntity> sourceEntities)
     {
-        var sourceEntities = new HashSet<object>();
-        foreach (var targetEntity in targetEntities)
+        var targetEntities = new HashSet<TTargetEntity>();
+        foreach (var sourceEntity in sourceEntities)
         {
-            var targetEntry = input.DbContext.Entry(targetEntity);
+            var targetEntry = input.DbContext.Entry(sourceEntity!);
             if (targetEntry.State == EntityState.Added)
                 throw new Exception("Cannot get old value of an added entity");
 
@@ -34,26 +37,28 @@ public class EFCoreEntityNavigation(
                 await navigationEntry.LoadAsync();
 
             foreach (var originalEntity in navigationEntry.GetOriginalEntities())
-                sourceEntities.Add(originalEntity);
+                targetEntities.Add((TTargetEntity)originalEntity);
         }
-        return sourceEntities;
+        return targetEntities;
     }
 
-    public virtual async Task<IReadOnlyCollection<object>> LoadCurrentAsync(IEFCoreComputedInput input, IReadOnlyCollection<object> targetEntities)
+    public virtual async Task<IReadOnlyCollection<TTargetEntity>> LoadCurrentAsync(
+        IEFCoreComputedInput input,
+        IReadOnlyCollection<TSourceEntity> sourceEntities)
     {
-        var sourceEntities = new HashSet<object>();
-        foreach (var targetEntity in targetEntities)
+        var targetEntities = new HashSet<TTargetEntity>();
+        foreach (var sourceEntitiy in sourceEntities)
         {
-            var entityEntry = input.DbContext.Entry(targetEntity);
+            var entityEntry = input.DbContext.Entry(sourceEntitiy!);
             var navigationEntry = entityEntry.Navigation(navigation);
 
             if (!navigationEntry.IsLoaded && entityEntry.State != EntityState.Detached)
                 await navigationEntry.LoadAsync();
 
             foreach (var entity in navigationEntry.GetEntities())
-                sourceEntities.Add(entity);
+                targetEntities.Add((TTargetEntity)entity);
         }
-        return sourceEntities;
+        return targetEntities;
     }
 
     public virtual string ToDebugString()
@@ -63,18 +68,18 @@ public class EFCoreEntityNavigation(
 
     public virtual IAffectedEntitiesProvider? GetAffectedEntitiesProvider()
     {
-        return new EFCoreNavigationAffectedEntitiesProvider(navigation);
+        return new EFCoreNavigationAffectedEntitiesProvider<TSourceEntity>(navigation);
     }
 
     public virtual Expression CreateOriginalValueExpression(
         IEntityMemberAccess<IEntityNavigation> memberAccess,
         Expression inputExpression)
     {
-        var originalValueGetter = static (INavigation navigation, IEFCoreComputedInput input, object ent) =>
+        var originalValueGetter = static (INavigation navigation, IEFCoreComputedInput input, TSourceEntity ent) =>
         {
             var dbContext = input.DbContext;
 
-            var entityEntry = dbContext.Entry(ent);
+            var entityEntry = dbContext.Entry(ent!);
 
             if (entityEntry.State == EntityState.Added)
                 throw new InvalidOperationException("Cannot retrieve the original value of an added entity");

--- a/src/LLL.ComputedExpression.EFCore/Internal/EFCoreEntityProperty.cs
+++ b/src/LLL.ComputedExpression.EFCore/Internal/EFCoreEntityProperty.cs
@@ -4,7 +4,9 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace LLL.ComputedExpression.EFCore.Internal;
 
-public class EFCoreEntityProperty(IProperty property) : IEntityProperty
+public class EFCoreEntityProperty<TEntity>(
+    IProperty property
+) : IEntityProperty<IEFCoreComputedInput, TEntity>
 {
     public virtual string Name => property.Name;
 
@@ -15,18 +17,18 @@ public class EFCoreEntityProperty(IProperty property) : IEntityProperty
 
     public virtual IAffectedEntitiesProvider? GetAffectedEntitiesProvider()
     {
-        return new EFCorePropertyAffectedEntitiesProvider(property);
+        return new EFCorePropertyAffectedEntitiesProvider<TEntity>(property);
     }
 
     public virtual Expression CreateOriginalValueExpression(
         IEntityMemberAccess<IEntityProperty> memberAccess,
         Expression inputExpression)
     {
-        var originalValueGetter = static (IProperty property, IEFCoreComputedInput input, object ent) =>
+        var originalValueGetter = static (IProperty property, IEFCoreComputedInput input, TEntity ent) =>
         {
             var dbContext = input.DbContext;
 
-            var entityEntry = dbContext.Entry(ent);
+            var entityEntry = dbContext.Entry(ent!);
 
             if (entityEntry.State == EntityState.Added)
                 throw new InvalidOperationException("Cannot retrieve the original value of an added entity");

--- a/src/LLL.ComputedExpression.EFCore/Internal/EFCoreMemberAccessLocator.cs
+++ b/src/LLL.ComputedExpression.EFCore/Internal/EFCoreMemberAccessLocator.cs
@@ -39,11 +39,13 @@ public class EFCoreMemberAccessLocator(IModel model) :
 
     protected virtual IEntityNavigation GetNavigation(INavigation navigation)
     {
-        return new EFCoreEntityNavigation(navigation);
+        var closedType = typeof(EFCoreEntityNavigation<,>).MakeGenericType(navigation.DeclaringEntityType.ClrType, navigation.TargetEntityType.ClrType);
+        return (IEntityNavigation)Activator.CreateInstance(closedType, navigation)!;
     }
 
     protected virtual IEntityProperty GetProperty(IProperty property)
     {
-        return new EFCoreEntityProperty(property);
+        var closedType = typeof(EFCoreEntityProperty<>).MakeGenericType(property.DeclaringEntityType.ClrType);
+        return (IEntityProperty)Activator.CreateInstance(closedType, property)!;
     }
 }

--- a/src/LLL.ComputedExpression.EFCore/Internal/EFCorePropertyAffectedEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression.EFCore/Internal/EFCorePropertyAffectedEntitiesProvider.cs
@@ -3,17 +3,17 @@ using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace LLL.ComputedExpression.EFCore.Internal;
 
-public class EFCorePropertyAffectedEntitiesProvider(IProperty property)
-      : IAffectedEntitiesProvider<IEFCoreComputedInput>
+public class EFCorePropertyAffectedEntitiesProvider<TEntity>(IProperty property)
+      : IAffectedEntitiesProvider<IEFCoreComputedInput, TEntity>
 {
     public virtual string ToDebugString()
     {
         return $"EntitiesWithPropertyChange({property.DeclaringType.ShortName()}, {property.Name})";
     }
 
-    public  virtual async Task<IReadOnlyCollection<object>> GetAffectedEntitiesAsync(IEFCoreComputedInput input)
+    public  virtual async Task<IReadOnlyCollection<TEntity>> GetAffectedEntitiesAsync(IEFCoreComputedInput input)
     {
-        var affectedEntities = new HashSet<object>();
+        var affectedEntities = new HashSet<TEntity>();
         foreach (var entityEntry in input.DbContext.ChangeTracker.Entries())
         {
             if (entityEntry.Metadata == property.DeclaringType)
@@ -22,7 +22,7 @@ public class EFCorePropertyAffectedEntitiesProvider(IProperty property)
                 if (entityEntry.State == EntityState.Added
                     || (entityEntry.State == EntityState.Modified && propertyEntry.IsModified)
                     || (entityEntry.State == EntityState.Deleted))
-                    affectedEntities.Add(entityEntry.Entity);
+                    affectedEntities.Add((TEntity)entityEntry.Entity);
             }
         }
         return affectedEntities;

--- a/src/LLL.ComputedExpression.EFCore/Internal/Utilities.cs
+++ b/src/LLL.ComputedExpression.EFCore/Internal/Utilities.cs
@@ -88,6 +88,7 @@ public static class Utilities
             yield return originalValue;
         }
     }
+    
     public static IEnumerable<object> GetEntities(this NavigationEntry navigationEntry)
     {
         var currentValue = navigationEntry.CurrentValue;

--- a/src/LLL.ComputedExpression/AffectedEntitiesProviders/CompositeAffectedEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/AffectedEntitiesProviders/CompositeAffectedEntitiesProvider.cs
@@ -1,10 +1,10 @@
 ﻿namespace LLL.ComputedExpression.AffectedEntitiesProviders;
 
-public class CompositeAffectedEntitiesProvider(
-    IReadOnlyCollection<IAffectedEntitiesProvider> providers
-) : IAffectedEntitiesProvider
+public class CompositeAffectedEntitiesProvider<TInput, TEntity>(
+    IReadOnlyCollection<IAffectedEntitiesProvider<TInput, TEntity>> providers
+) : IAffectedEntitiesProvider<TInput, TEntity>
 {
-    private readonly IReadOnlyCollection<IAffectedEntitiesProvider> _providers = providers;
+    private readonly IReadOnlyCollection<IAffectedEntitiesProvider<TInput, TEntity>> _providers = providers;
 
     public string ToDebugString()
     {
@@ -13,9 +13,9 @@ public class CompositeAffectedEntitiesProvider(
         return $"Concat({inner})";
     }
 
-    public async Task<IReadOnlyCollection<object>> GetAffectedEntitiesAsync(object input)
+    public async Task<IReadOnlyCollection<TEntity>> GetAffectedEntitiesAsync(TInput input)
     {
-        var entities = new HashSet<object>();
+        var entities = new HashSet<TEntity>();
         foreach (var provider in _providers)
         {
             foreach (var entity in await provider.GetAffectedEntitiesAsync(input))

--- a/src/LLL.ComputedExpression/AffectedEntitiesProviders/LoadNavigationAffectedEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/AffectedEntitiesProviders/LoadNavigationAffectedEntitiesProvider.cs
@@ -1,16 +1,16 @@
 ﻿namespace LLL.ComputedExpression.AffectedEntitiesProviders;
 
-public class LoadNavigationAffectedEntitiesProvider(
-    IAffectedEntitiesProvider affectedEntitiesProvider,
-    IEntityNavigation navigation
-) : IAffectedEntitiesProvider
+public class LoadNavigationAffectedEntitiesProvider<TInput, TSourceEntity, TTargetEntity>(
+    IAffectedEntitiesProvider<TInput, TSourceEntity> affectedEntitiesProvider,
+    IEntityNavigation<TInput, TSourceEntity, TTargetEntity> navigation
+) : IAffectedEntitiesProvider<TInput, TTargetEntity>
 {
     public string ToDebugString()
     {
         return $"Load({affectedEntitiesProvider.ToDebugString()}, {navigation.Name})";
     }
 
-    public async Task<IReadOnlyCollection<object>> GetAffectedEntitiesAsync(object input)
+    public async Task<IReadOnlyCollection<TTargetEntity>> GetAffectedEntitiesAsync(TInput input)
     {
         var affectedEntities = await affectedEntitiesProvider.GetAffectedEntitiesAsync(input);
         return await navigation.LoadCurrentAsync(input, affectedEntities);

--- a/src/LLL.ComputedExpression/ComputedExpressionAnalysis.cs
+++ b/src/LLL.ComputedExpression/ComputedExpressionAnalysis.cs
@@ -4,13 +4,17 @@ using LLL.ComputedExpression.EntityContexts;
 
 namespace LLL.ComputedExpression;
 
-public class ComputedExpressionAnalysis(IComputedExpressionAnalyzer analyzer) : IComputedExpressionAnalysis
+public class ComputedExpressionAnalysis(
+    IComputedExpressionAnalyzer analyzer,
+    Type rootEntityType)
+    : IComputedExpressionAnalysis
 {
     private readonly ConcurrentDictionary<Expression, ConcurrentBag<Func<string, EntityContext?>>> _entityContextProviders = new();
     private readonly ConcurrentDictionary<(Expression, string), EntityContext> _entityContextCache = new();
     private readonly ConcurrentDictionary<Expression, IEntityMemberAccess<IEntityMember>> _entityMemberAccesses = new();
 
-    public IComputedExpressionAnalyzer Analyzer { get; } = analyzer;
+    public IComputedExpressionAnalyzer Analyzer => analyzer;
+    public Type RootEntityType => rootEntityType;
 
     public EntityContext ResolveEntityContext(Expression node, string key)
     {

--- a/src/LLL.ComputedExpression/EntityContextPropagators/UntrackedEntityContextPropagator.cs
+++ b/src/LLL.ComputedExpression/EntityContextPropagators/UntrackedEntityContextPropagator.cs
@@ -3,13 +3,13 @@ using LLL.ComputedExpression.EntityContexts;
 
 namespace LLL.ComputedExpression.EntityContextPropagators;
 
-public class UntrackedEntityContextPropagator(
+public class UntrackedEntityContextPropagator<TInput>(
     IStopTrackingDecision stopTrackingDecision
 ) : IEntityContextPropagator
 {
     public void PropagateEntityContext(Expression node, IComputedExpressionAnalysis analysis)
     {
         if (stopTrackingDecision.ShouldStopTracking(node))
-            analysis.AddEntityContextProvider(node, (key) => new UntrackedEntityContext());
+            analysis.AddEntityContextProvider(node, (key) => new UntrackedEntityContext(typeof(TInput), node.Type, analysis.RootEntityType));
     }
 }

--- a/src/LLL.ComputedExpression/EntityContexts/EntityContext.cs
+++ b/src/LLL.ComputedExpression/EntityContexts/EntityContext.cs
@@ -10,6 +10,9 @@ public abstract class EntityContext
     public IEnumerable<IEntityMember> AccessedMembers => _accessedMembers;
     public IEnumerable<EntityContext> ChildContexts => _childContexts;
 
+    public abstract Type InputType { get; }
+    public abstract Type RootEntityType { get; }
+    public abstract Type EntityType { get; }
     public abstract bool IsTrackingChanges { get; }
 
     public void RegisterAccessedMember(IEntityMember member)

--- a/src/LLL.ComputedExpression/EntityContexts/RootEntityContext.cs
+++ b/src/LLL.ComputedExpression/EntityContexts/RootEntityContext.cs
@@ -2,8 +2,11 @@
 
 namespace LLL.ComputedExpression.EntityContexts;
 
-public class RootEntityContext : EntityContext
+public class RootEntityContext(Type inputType, Type entityType) : EntityContext
 {
+    public override Type InputType => inputType;
+    public override Type EntityType => entityType;
+    public override Type RootEntityType => entityType;
     public override bool IsTrackingChanges => true;
 
     public override IAffectedEntitiesProvider? GetParentAffectedEntitiesProvider()
@@ -18,11 +21,17 @@ public class RootEntityContext : EntityContext
 
     public override IRootEntitiesProvider GetOriginalRootEntitiesProvider()
     {
-        return new NoOpRootEntitiesProvider();
+        var closedType = typeof(NoOpRootEntitiesProvider<,>)
+            .MakeGenericType(InputType, EntityType);
+
+        return (IRootEntitiesProvider)Activator.CreateInstance(closedType)!;
     }
 
     public override IRootEntitiesProvider GetCurrentRootEntitiesProvider()
     {
-        return new NoOpRootEntitiesProvider();
+        var closedType = typeof(NoOpRootEntitiesProvider<,>)
+            .MakeGenericType(InputType, EntityType);
+
+        return (IRootEntitiesProvider)Activator.CreateInstance(closedType)!;
     }
 }

--- a/src/LLL.ComputedExpression/EntityContexts/ScopedEntityContext.cs
+++ b/src/LLL.ComputedExpression/EntityContexts/ScopedEntityContext.cs
@@ -1,3 +1,4 @@
+
 namespace LLL.ComputedExpression.EntityContexts;
 
 public class ScopedEntityContext : EntityContext
@@ -7,10 +8,17 @@ public class ScopedEntityContext : EntityContext
     public ScopedEntityContext(EntityContext parent)
     {
         _parent = parent;
+        InputType = parent.InputType;
+        EntityType = parent.EntityType;
+        RootEntityType = parent.RootEntityType;
         IsTrackingChanges = parent.IsTrackingChanges;
         parent.RegisterChildContext(this);
     }
 
+
+    public override Type InputType { get; }
+    public override Type EntityType { get; }
+    public override Type RootEntityType {get;}
     public override bool IsTrackingChanges { get; }
 
     public override IAffectedEntitiesProvider? GetParentAffectedEntitiesProvider()

--- a/src/LLL.ComputedExpression/EntityContexts/UntrackedEntityContext.cs
+++ b/src/LLL.ComputedExpression/EntityContexts/UntrackedEntityContext.cs
@@ -2,8 +2,15 @@
 
 namespace LLL.ComputedExpression.EntityContexts;
 
-public class UntrackedEntityContext : EntityContext
+public class UntrackedEntityContext(
+    Type inputType,
+    Type entityType,
+    Type rootEntityType
+) : EntityContext
 {
+    public override Type InputType => inputType;
+    public override Type EntityType => entityType;
+    public override Type RootEntityType => rootEntityType;
     public override bool IsTrackingChanges => false;
 
     public override IAffectedEntitiesProvider? GetParentAffectedEntitiesProvider()
@@ -18,13 +25,17 @@ public class UntrackedEntityContext : EntityContext
 
     public override IRootEntitiesProvider GetOriginalRootEntitiesProvider()
     {
-        // TODO: Implement
-        return new EmptyRootEntitiesProvider();
+        var closedType = typeof(EmptyRootEntitiesProvider<,,>)
+            .MakeGenericType(InputType, RootEntityType, EntityType);
+
+        return (IRootEntitiesProvider)Activator.CreateInstance(closedType)!;
     }
 
     public override IRootEntitiesProvider GetCurrentRootEntitiesProvider()
     {
-        // TODO: Implement
-        return new EmptyRootEntitiesProvider();
+        var closedType = typeof(EmptyRootEntitiesProvider<,,>)
+            .MakeGenericType(InputType, RootEntityType, EntityType);
+
+        return (IRootEntitiesProvider)Activator.CreateInstance(closedType)!;
     }
 }

--- a/src/LLL.ComputedExpression/IAffectedEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/IAffectedEntitiesProvider.cs
@@ -2,24 +2,41 @@
 
 public interface IAffectedEntitiesProvider
 {
+    Type InputType { get; }
+    Type EntityType { get; }
+
     Task<IReadOnlyCollection<object>> GetAffectedEntitiesAsync(object input);
 
     string ToDebugString();
 
-    IReadOnlyCollection<IAffectedEntitiesProvider> Flatten() {
+    IReadOnlyCollection<IAffectedEntitiesProvider> Flatten()
+    {
         return [this];
     }
 }
 
-public interface IAffectedEntitiesProvider<in TInput> : IAffectedEntitiesProvider
+public interface IAffectedEntitiesProvider<in TInput, TEntity> : IAffectedEntitiesProvider
 {
-    Task<IReadOnlyCollection<object>> GetAffectedEntitiesAsync(TInput input);
+    Type IAffectedEntitiesProvider.InputType => typeof(TInput);
+    Type IAffectedEntitiesProvider.EntityType => typeof(TEntity);
 
-    Task<IReadOnlyCollection<object>> IAffectedEntitiesProvider.GetAffectedEntitiesAsync(object input)
+    Task<IReadOnlyCollection<TEntity>> GetAffectedEntitiesAsync(TInput input);
+
+    new IReadOnlyCollection<IAffectedEntitiesProvider<TInput, TEntity>> Flatten()
+    {
+        return [this];
+    }
+
+    async Task<IReadOnlyCollection<object>> IAffectedEntitiesProvider.GetAffectedEntitiesAsync(object input)
     {
         if (input is not TInput inputTyped)
             throw new ArgumentException($"Param {nameof(input)} should be of type {typeof(TInput)}");
 
-        return GetAffectedEntitiesAsync(inputTyped);
+        return (IReadOnlyCollection<object>)await GetAffectedEntitiesAsync(inputTyped);
+    }
+
+    IReadOnlyCollection<IAffectedEntitiesProvider> IAffectedEntitiesProvider.Flatten()
+    {
+        return Flatten();
     }
 }

--- a/src/LLL.ComputedExpression/IChangesProvider.cs
+++ b/src/LLL.ComputedExpression/IChangesProvider.cs
@@ -4,3 +4,20 @@ public interface IChangesProvider
 {
     Task<IDictionary<object, (object? OriginalValue, object? NewValue)>> GetChangesAsync(object input);
 }
+
+public interface IChangesProvider<in TInput, TEntity, TValue> : IChangesProvider
+{
+    Task<IReadOnlyDictionary<TEntity, (TValue? OriginalValue, TValue? NewValue)>> GetChangesAsync(TInput input);
+
+    async Task<IDictionary<object, (object? OriginalValue, object? NewValue)>> IChangesProvider.GetChangesAsync(object input)
+    {
+        if (input is not TInput inputTyped)
+            throw new ArgumentException($"Param {nameof(input)} should be of type {typeof(TInput)}");
+
+        var changes = await GetChangesAsync(inputTyped);
+        
+        return changes.ToDictionary(
+            x => (object)x.Key!,
+            x => ((object?)x.Value.OriginalValue, (object?)x.Value.NewValue));
+    }
+}

--- a/src/LLL.ComputedExpression/IComputedExpressionAnalysis.cs
+++ b/src/LLL.ComputedExpression/IComputedExpressionAnalysis.cs
@@ -6,6 +6,7 @@ namespace LLL.ComputedExpression;
 public interface IComputedExpressionAnalysis
 {
     IComputedExpressionAnalyzer Analyzer { get; }
+    Type RootEntityType { get; }
     EntityContext ResolveEntityContext(Expression node, string key);
     void PropagateEntityContext(Expression fromNode, string fromKey, Expression toNode, string toKey, Func<EntityContext, EntityContext>? mapper = null);
     void PropagateEntityContext((Expression fromNode, string fromKey)[] fromNodesKeys, Expression toNode, string toKey, Func<EntityContext, EntityContext>? mapper = null);

--- a/src/LLL.ComputedExpression/IEntityActionProvider.cs
+++ b/src/LLL.ComputedExpression/IEntityActionProvider.cs
@@ -5,7 +5,7 @@ public interface IEntityActionProvider
     EntityAction GetEntityAction(object input, object entity);
 }
 
-public interface IEntityActionProvider<TInput> : IEntityActionProvider
+public interface IEntityActionProvider<in TInput> : IEntityActionProvider
 {
     EntityAction GetEntityAction(TInput input, object entity);
 

--- a/src/LLL.ComputedExpression/IEntityNavigation.cs
+++ b/src/LLL.ComputedExpression/IEntityNavigation.cs
@@ -2,38 +2,39 @@
 
 public interface IEntityNavigation : IEntityMember<IEntityNavigation>
 {
+    Type TargetEntityType { get; }
     bool IsCollection { get; }
     IEntityNavigation GetInverse();
     Task<IReadOnlyCollection<object>> LoadCurrentAsync(object input, IReadOnlyCollection<object> fromEntities);
     Task<IReadOnlyCollection<object>> LoadOriginalAsync(object input, IReadOnlyCollection<object> fromEntities);
 }
 
-public interface IEntityNavigation<in TInput> : IEntityNavigation
+public interface IEntityNavigation<in TInput, TSourceEntity, TTargetEntity> : IEntityNavigation
 {
-    new IEntityNavigation<TInput> GetInverse();
+    new IEntityNavigation<TInput, TTargetEntity, TSourceEntity> GetInverse();
 
     IEntityNavigation IEntityNavigation.GetInverse()
     {
         return GetInverse();
     }
 
-    Task<IReadOnlyCollection<object>> LoadCurrentAsync(TInput input, IReadOnlyCollection<object> fromEntities);
+    Task<IReadOnlyCollection<TTargetEntity>> LoadCurrentAsync(TInput input, IReadOnlyCollection<TSourceEntity> fromEntities);
 
-    Task<IReadOnlyCollection<object>> LoadOriginalAsync(TInput input, IReadOnlyCollection<object> fromEntities);
+    Task<IReadOnlyCollection<TTargetEntity>> LoadOriginalAsync(TInput input, IReadOnlyCollection<TSourceEntity> fromEntities);
 
-    Task<IReadOnlyCollection<object>> IEntityNavigation.LoadCurrentAsync(object input, IReadOnlyCollection<object> fromEntities)
+    async Task<IReadOnlyCollection<object>> IEntityNavigation.LoadCurrentAsync(object input, IReadOnlyCollection<object> fromEntities)
     {
         if (input is not TInput inputTyped)
             throw new ArgumentException($"Param {nameof(input)} should be of type {typeof(TInput)}");
 
-        return LoadCurrentAsync(inputTyped, fromEntities);
+        return (IReadOnlyCollection<object>)await LoadCurrentAsync(inputTyped, fromEntities.OfType<TSourceEntity>().ToArray());
     }
 
-    Task<IReadOnlyCollection<object>> IEntityNavigation.LoadOriginalAsync(object input, IReadOnlyCollection<object> fromEntities)
+    async Task<IReadOnlyCollection<object>> IEntityNavigation.LoadOriginalAsync(object input, IReadOnlyCollection<object> fromEntities)
     {
         if (input is not TInput inputTyped)
             throw new ArgumentException($"Param {nameof(input)} should be of type {typeof(TInput)}");
 
-        return LoadOriginalAsync(inputTyped, fromEntities);
+        return (IReadOnlyCollection<object>)await LoadOriginalAsync(inputTyped, fromEntities.OfType<TSourceEntity>().ToArray());
     }
 }

--- a/src/LLL.ComputedExpression/IEntityProperty.cs
+++ b/src/LLL.ComputedExpression/IEntityProperty.cs
@@ -3,3 +3,7 @@ namespace LLL.ComputedExpression;
 public interface IEntityProperty : IEntityMember<IEntityProperty>
 {
 }
+
+public interface IEntityProperty<in TInput, TEntity> : IEntityProperty
+{
+}

--- a/src/LLL.ComputedExpression/IIncrementalChangesProvider.cs
+++ b/src/LLL.ComputedExpression/IIncrementalChangesProvider.cs
@@ -2,5 +2,22 @@ namespace LLL.ComputedExpression;
 
 public interface IIncrementalChangesProvider
 {
-    Task<IDictionary<object, object?>> GetIncrementalChangesAsync(object input);
+    Task<IReadOnlyDictionary<object, object?>> GetIncrementalChangesAsync(object input);
+}
+
+public interface IIncrementalChangesProvider<in TInput, TEntity, TValue> : IIncrementalChangesProvider
+{
+    Task<IReadOnlyDictionary<TEntity, TValue>> GetIncrementalChangesAsync(TInput input);
+
+    async Task<IReadOnlyDictionary<object, object?>> IIncrementalChangesProvider.GetIncrementalChangesAsync(object input)
+    {
+        if (input is not TInput inputTyped)
+            throw new ArgumentException($"Param {nameof(input)} should be of type {typeof(TInput)}");
+
+        var changes = await GetIncrementalChangesAsync(inputTyped);
+
+        return changes.ToDictionary(
+            x => (object)x.Key!,
+            x => (object?)x.Value);
+    }
 }

--- a/src/LLL.ComputedExpression/IRootEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/IRootEntitiesProvider.cs
@@ -4,3 +4,18 @@ public interface IRootEntitiesProvider
 {
     Task<IReadOnlyCollection<object>> GetRootEntities(object input, IReadOnlyCollection<object> entities);
 }
+
+public interface IRootEntitiesProvider<in TInput, TRootEntity, TSourceEntity> : IRootEntitiesProvider
+{
+    Task<IReadOnlyCollection<TRootEntity>> GetRootEntities(TInput input, IReadOnlyCollection<TSourceEntity> entities);
+
+    async Task<IReadOnlyCollection<object>> IRootEntitiesProvider.GetRootEntities(object input, IReadOnlyCollection<object> entities)
+    {
+        if (input is not TInput inputTyped)
+            throw new ArgumentException($"Param {nameof(input)} should be of type {typeof(TInput)}");
+
+        var entitiesTyped = entities.Cast<TSourceEntity>().ToArray();
+
+        return (IReadOnlyCollection<object>)await GetRootEntities(inputTyped, entitiesTyped);
+    }
+}

--- a/src/LLL.ComputedExpression/Incremental/IIncrementalComputed.cs
+++ b/src/LLL.ComputedExpression/Incremental/IIncrementalComputed.cs
@@ -2,6 +2,8 @@ namespace LLL.ComputedExpression.Incremental;
 
 public interface IIncrementalComputed
 {
+    Type EntityType { get; }
+    Type ValueType { get; }
     object? Zero { get; }
     bool IsZero(object? value);
     object? Add(object? a, object? b);
@@ -9,31 +11,33 @@ public interface IIncrementalComputed
     List<IncrementalComputedPart> Parts { get; }
 }
 
-public interface IIncrementalComputed<T, V> : IIncrementalComputed
+public interface IIncrementalComputed<TEntity, TValue> : IIncrementalComputed
 {
-    new V Zero { get; }
-    bool IsZero(V value);
-    V Add(V a, V b);
-    V Remove(V a, V b);
+    new TValue Zero { get; }
+    bool IsZero(TValue value);
+    TValue Add(TValue a, TValue b);
+    TValue Remove(TValue a, TValue b);
+    Type IIncrementalComputed.EntityType => typeof(TEntity);
+    Type IIncrementalComputed.ValueType => typeof(TValue);
     object? IIncrementalComputed.Zero => Zero;
-    bool IIncrementalComputed.IsZero(object? value) => value is V v && IsZero(v);
+    bool IIncrementalComputed.IsZero(object? value) => value is TValue v && IsZero(v);
     object? IIncrementalComputed.Add(object? a, object? b)
     {
-        if (a is not V aTyped)
-            throw new ArgumentException($"Param {nameof(a)} should be of type {typeof(V)}");
+        if (a is not TValue aTyped)
+            throw new ArgumentException($"Param {nameof(a)} should be of type {typeof(TValue)}");
 
-        if (b is not V bTyped)
-            throw new ArgumentException($"Param {nameof(b)} should be of type {typeof(V)}");
+        if (b is not TValue bTyped)
+            throw new ArgumentException($"Param {nameof(b)} should be of type {typeof(TValue)}");
 
         return Add(aTyped, bTyped);
     }
     object? IIncrementalComputed.Remove(object? a, object? b)
     {
-        if (a is not V aTyped)
-            throw new ArgumentException($"Param {nameof(a)} should be of type {typeof(V)}");
+        if (a is not TValue aTyped)
+            throw new ArgumentException($"Param {nameof(a)} should be of type {typeof(TValue)}");
 
-        if (b is not V bTyped)
-            throw new ArgumentException($"Param {nameof(b)} should be of type {typeof(V)}");
+        if (b is not TValue bTyped)
+            throw new ArgumentException($"Param {nameof(b)} should be of type {typeof(TValue)}");
 
         return Remove(aTyped, bTyped);
     }

--- a/src/LLL.ComputedExpression/IncrementalChangesProvider/CompositeIncrementalChangesProvider.cs
+++ b/src/LLL.ComputedExpression/IncrementalChangesProvider/CompositeIncrementalChangesProvider.cs
@@ -4,14 +4,15 @@ using LLL.ComputedExpression.Incremental;
 
 namespace LLL.ComputedExpression.IncrementalChangesProvider;
 
-public class CompositeIncrementalChangesProvider(
-    IIncrementalComputed incrementalComputed,
-    IReadOnlyCollection<IIncrementalChangesProvider> providers
-) : IIncrementalChangesProvider
+public class CompositeIncrementalChangesProvider<TInput, TRootEntity, TValue>(
+    IIncrementalComputed<TRootEntity, TValue> incrementalComputed,
+    IReadOnlyCollection<IIncrementalChangesProvider<TInput, TRootEntity, TValue>> providers
+) : IIncrementalChangesProvider<TInput, TRootEntity, TValue>
+    where TRootEntity : notnull
 {
-    public async Task<IDictionary<object, object?>> GetIncrementalChangesAsync(object input)
+    public async Task<IReadOnlyDictionary<TRootEntity, TValue>> GetIncrementalChangesAsync(TInput input)
     {
-        var aggregated = new ConcurrentDictionary<object, object?>();
+        var aggregated = new ConcurrentDictionary<TRootEntity, TValue>();
 
         foreach (var provider in providers)
         {

--- a/src/LLL.ComputedExpression/Internal/EnumerableExtensions.cs
+++ b/src/LLL.ComputedExpression/Internal/EnumerableExtensions.cs
@@ -1,0 +1,16 @@
+using System.Collections;
+
+namespace LLL.ComputedExpression.Internal;
+
+public static class EnumerableExtensions
+{
+    public static Array ToArray(this IEnumerable source, Type type)
+    {
+        return (Array)typeof(Enumerable).GetMethod(nameof(Enumerable.ToArray))!
+            .MakeGenericMethod(type)
+            .Invoke(null, [
+                typeof(Enumerable).GetMethod(nameof(Enumerable.Cast))!
+                    .MakeGenericMethod(type).Invoke(null, [source])
+            ])!;
+    }
+}

--- a/src/LLL.ComputedExpression/RootEntitiesProvider/CompositeRootEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/RootEntitiesProvider/CompositeRootEntitiesProvider.cs
@@ -1,13 +1,13 @@
 
 namespace LLL.ComputedExpression.RootEntitiesProvider;
 
-public class CompositeRootEntitiesProvider(
-    IReadOnlyCollection<IRootEntitiesProvider> providers
-) : IRootEntitiesProvider
+public class CompositeRootEntitiesProvider<TInput, TRootEntity, TSourceEntity>(
+    IReadOnlyCollection<IRootEntitiesProvider<TInput, TRootEntity, TSourceEntity>> providers
+) : IRootEntitiesProvider<TInput, TRootEntity, TSourceEntity>
 {
-    public async Task<IReadOnlyCollection<object>> GetRootEntities(object input, IReadOnlyCollection<object> entities)
+    public async Task<IReadOnlyCollection<TRootEntity>> GetRootEntities(TInput input, IReadOnlyCollection<TSourceEntity> entities)
     {
-        var rootEntities = new HashSet<object>();
+        var rootEntities = new HashSet<TRootEntity>();
         foreach (var provider in providers)
         {
             foreach (var rootEntity in await provider.GetRootEntities(input, entities))

--- a/src/LLL.ComputedExpression/RootEntitiesProvider/EmptyRootEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/RootEntitiesProvider/EmptyRootEntitiesProvider.cs
@@ -1,9 +1,9 @@
 
 namespace LLL.ComputedExpression.RootEntitiesProvider;
 
-public class EmptyRootEntitiesProvider : IRootEntitiesProvider
+public class EmptyRootEntitiesProvider<TInput, TRootEntity, TSourceEntity> : IRootEntitiesProvider<TInput, TRootEntity, TSourceEntity>
 {
-    public async Task<IReadOnlyCollection<object>> GetRootEntities(object input, IReadOnlyCollection<object> entities)
+    public async Task<IReadOnlyCollection<TRootEntity>> GetRootEntities(TInput input, IReadOnlyCollection<TSourceEntity> entities)
     {
         return [];
     }

--- a/src/LLL.ComputedExpression/RootEntitiesProvider/FilteredRootEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/RootEntitiesProvider/FilteredRootEntitiesProvider.cs
@@ -1,13 +1,13 @@
 ﻿namespace LLL.ComputedExpression.RootEntitiesProvider;
 
-public class FilteredRootEntitiesProvider(
-    IRootEntitiesProvider parent,
-    Delegate filter
-) : IRootEntitiesProvider
+public class FilteredRootEntitiesProvider<TInput, TRootEntity, TSourceEntity>(
+    IRootEntitiesProvider<TInput, TRootEntity, TSourceEntity> parent,
+    Func<TInput, TSourceEntity, bool> filter
+) : IRootEntitiesProvider<TInput, TRootEntity, TSourceEntity>
 {
-    public async Task<IReadOnlyCollection<object>> GetRootEntities(object input, IReadOnlyCollection<object> entities)
+    public async Task<IReadOnlyCollection<TRootEntity>> GetRootEntities(TInput input, IReadOnlyCollection<TSourceEntity> entities)
     {
-        var filteredEntities = entities.Where(e => (bool)filter.DynamicInvoke(input, e)!).ToArray();
+        var filteredEntities = entities.Where(e => filter(input, e)).ToArray();
         return await parent.GetRootEntities(input, filteredEntities);
     }
 }

--- a/src/LLL.ComputedExpression/RootEntitiesProvider/LoadCurrentNavigationRootEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/RootEntitiesProvider/LoadCurrentNavigationRootEntitiesProvider.cs
@@ -1,11 +1,11 @@
 ﻿namespace LLL.ComputedExpression.RootEntitiesProvider;
 
-public class LoadCurrentNavigationRootEntitiesProvider(
-    IRootEntitiesProvider parent,
-    IEntityNavigation navigation
-) : IRootEntitiesProvider
+public class LoadCurrentNavigationRootEntitiesProvider<TInput, TRootEntity, TSourceEntity, TTargetEnitty>(
+    IRootEntitiesProvider<TInput, TRootEntity, TTargetEnitty> parent,
+    IEntityNavigation<TInput, TSourceEntity, TTargetEnitty> navigation
+) : IRootEntitiesProvider<TInput, TRootEntity, TSourceEntity>
 {
-    public async Task<IReadOnlyCollection<object>> GetRootEntities(object input, IReadOnlyCollection<object> entities)
+    public async Task<IReadOnlyCollection<TRootEntity>> GetRootEntities(TInput input, IReadOnlyCollection<TSourceEntity> entities)
     {
         var targetEntities = await navigation.LoadCurrentAsync(input, entities);
         return await parent.GetRootEntities(input, targetEntities);

--- a/src/LLL.ComputedExpression/RootEntitiesProvider/LoadOriginalNavigationRootEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/RootEntitiesProvider/LoadOriginalNavigationRootEntitiesProvider.cs
@@ -1,11 +1,11 @@
 ﻿namespace LLL.ComputedExpression.RootEntitiesProvider;
 
-public class LoadOriginalNavigationRootEntitiesProvider(
-    IRootEntitiesProvider parent,
-    IEntityNavigation navigation
-) : IRootEntitiesProvider
+public class LoadOriginalNavigationRootEntitiesProvider<TInput, TRootEntity, TSourceEntity, TTargetEnitty>(
+    IRootEntitiesProvider<TInput, TRootEntity, TTargetEnitty> parent,
+    IEntityNavigation<TInput, TSourceEntity, TTargetEnitty> navigation
+) : IRootEntitiesProvider<TInput, TRootEntity, TSourceEntity>
 {
-    public async Task<IReadOnlyCollection<object>> GetRootEntities(object input, IReadOnlyCollection<object> entities)
+    public async Task<IReadOnlyCollection<TRootEntity>> GetRootEntities(TInput input, IReadOnlyCollection<TSourceEntity> entities)
     {
         var targetEntities = await navigation.LoadOriginalAsync(input, entities);
         return await parent.GetRootEntities(input, targetEntities);

--- a/src/LLL.ComputedExpression/RootEntitiesProvider/NoOpRootEntitiesProvider.cs
+++ b/src/LLL.ComputedExpression/RootEntitiesProvider/NoOpRootEntitiesProvider.cs
@@ -1,9 +1,10 @@
 
 namespace LLL.ComputedExpression.RootEntitiesProvider;
 
-public class NoOpRootEntitiesProvider : IRootEntitiesProvider
+public class NoOpRootEntitiesProvider<TInput, TEntity>
+    : IRootEntitiesProvider<TInput, TEntity, TEntity>
 {
-    public async Task<IReadOnlyCollection<object>> GetRootEntities(object input, IReadOnlyCollection<object> entities)
+    public async Task<IReadOnlyCollection<TEntity>> GetRootEntities(TInput input, IReadOnlyCollection<TEntity> entities)
     {
         return entities;
     }

--- a/test/LLL.ComputedExpression.EFCore.Tests/AffectedEntities/BasicOperationsTests.cs
+++ b/test/LLL.ComputedExpression.EFCore.Tests/AffectedEntities/BasicOperationsTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq.Expressions;
 using FluentAssertions;
+using LLL.ComputedExpression.EFCore.Internal;
 
 namespace LLL.ComputedExpression.EFCore.Tests.AffectedEntities;
 

--- a/test/LLL.ComputedExpression.EFCore.Tests/AffectedEntities/CollectionTests.cs
+++ b/test/LLL.ComputedExpression.EFCore.Tests/AffectedEntities/CollectionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq.Expressions;
 using FluentAssertions;
+using LLL.ComputedExpression.EFCore.Internal;
 
 namespace LLL.ComputedExpression.EFCore.Tests.AffectedEntities;
 

--- a/test/LLL.ComputedExpression.EFCore.Tests/AffectedEntities/FilteredCollectionTests.cs
+++ b/test/LLL.ComputedExpression.EFCore.Tests/AffectedEntities/FilteredCollectionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq.Expressions;
 using FluentAssertions;
+using LLL.ComputedExpression.EFCore.Internal;
 
 namespace LLL.ComputedExpression.EFCore.Tests.AffectedEntities;
 

--- a/test/LLL.ComputedExpression.EFCore.Tests/AffectedEntities/StopTrackingTests.cs
+++ b/test/LLL.ComputedExpression.EFCore.Tests/AffectedEntities/StopTrackingTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using LLL.ComputedExpression.EFCore.Internal;
 
 namespace LLL.ComputedExpression.EFCore.Tests.AffectedEntities;
 


### PR DESCRIPTION
Use generics for AffectedEntitiesProviders, ChangesProvider, IncrementalChangesProvider to avoid type casting after analysis time.