### PR TITLE
Add .NET 10 support and update packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -73,7 +76,10 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
       - name: Create Release NuGet package
         run: |
           export Version=${GITHUB_REF:11}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md - LLL.AutoCompute
+
+## Project Overview
+
+LLL.AutoCompute is an open-source library for automatically computing and updating properties in Entity Framework Core. It supports multi-targeting across .NET 8, 9, and 10.
+
+## Build & Test
+
+```bash
+dotnet build
+dotnet test
+```
+
+## Language
+
+English for everything (code, commits, PRs, docs).
+
+## Package Versioning
+
+- **Library projects** (`src/`): Use base versions (`x.0.0`) for Microsoft.Extensions.* and Microsoft.EntityFrameworkCore.* packages to avoid forcing consumers to update to a specific patch version.
+- **Test projects** (`test/`): Use latest stable patch versions since they don't ship to consumers.
+
+## Multi-targeting
+
+All projects target `net10.0;net9.0;net8.0`. Use conditional `ItemGroup` or `Condition` attributes for framework-specific package references.
+
+## Git Conventions
+
+- Commit messages in English, imperative present tense
+- Main branch: `main`

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
+++ b/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
@@ -29,11 +29,17 @@
     <ProjectReference Include="..\LLL.AutoCompute.EFCore\LLL.AutoCompute.EFCore.csproj" />
   </ItemGroup>
 
+  <!--
+    npm install/build runs before DispatchToInnerBuilds (outer build, TargetFramework is empty)
+    to avoid parallel npm executions across TFMs racing on node_modules.
+    The !Exists check is a fallback for single-TFM builds (e.g. dotnet build -f net9.0)
+    where DispatchToInnerBuilds is not invoked.
+  -->
   <Target Name="NpmInstall" BeforeTargets="NpmBuild" Inputs="ClientApp/package.json" Outputs="ClientApp/node_modules/.package-lock.json">
     <Exec Command="npm install" WorkingDirectory="ClientApp" />
   </Target>
 
-  <Target Name="NpmBuild" BeforeTargets="BeforeBuild" Inputs="ClientApp/src/**;ClientApp/index.html;ClientApp/vite.config.ts;ClientApp/tsconfig.json" Outputs="wwwroot/index.html">
+  <Target Name="NpmBuild" BeforeTargets="DispatchToInnerBuilds;BeforeBuild" Condition="'$(TargetFramework)' == '' or !Exists('wwwroot/index.html')" Inputs="ClientApp/src/**;ClientApp/index.html;ClientApp/vite.config.ts;ClientApp/tsconfig.json" Outputs="wwwroot/index.html">
     <Exec Command="npm run build" WorkingDirectory="ClientApp" />
   </Target>
 

--- a/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
+++ b/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -16,7 +16,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/LLL.AutoCompute.EFCore/Internal/AutoComputeMigrationsModelDiffer.cs
+++ b/src/LLL.AutoCompute.EFCore/Internal/AutoComputeMigrationsModelDiffer.cs
@@ -153,33 +153,36 @@ public class AutoComputeMigrationsModelDiffer(
         }
         var propSelector = Expression.Lambda<Func<TEntity, TProperty>>(propAccess, eParam);
 
-        // 3. Build SetPropertyCalls expression: s => s.SetProperty(e => e.Prop, computedExpr)
-        //    SetProperty takes Func<> params. LambdaExpression.Type returns the delegate type
-        //    (e.g. Func<T,P>), so passing lambdas directly to Expression.Call works.
-        var sParam = Expression.Parameter(typeof(SetPropertyCalls<TEntity>), "s");
-
-        var setPropertyMethod = typeof(SetPropertyCalls<TEntity>)
-            .GetMethods()
-            .First(m => m.Name == "SetProperty"
-                && m.IsGenericMethodDefinition
-                && m.GetParameters().Length == 2
-                && m.GetParameters()[1].ParameterType.IsGenericType
-                && m.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>))
-            .MakeGenericMethod(typeof(TProperty));
-
-        var setPropertyCall = Expression.Call(
-            sParam,
-            setPropertyMethod,
-            propSelector,
-            preparedExpr);
-
-        var setPropertyCallsExpr = Expression.Lambda<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>>(
-            setPropertyCall, sParam);
-
-        // 4. Capture SQL via interceptor
+        // 3. Call ExecuteUpdate with SetProperty
         using (SqlCaptureInterceptor.StartCapture())
         {
+#if NET10_0_OR_GREATER
+            // EF Core 10: ExecuteUpdate takes Action<UpdateSettersBuilder<T>>
+            dbContext.Set<TEntity>().ExecuteUpdate(s => s.SetProperty(propSelector, preparedExpr));
+#else
+            // EF Core 8/9: ExecuteUpdate takes Expression<Func<SetPropertyCalls<T>, SetPropertyCalls<T>>>
+            var sParam = Expression.Parameter(typeof(SetPropertyCalls<TEntity>), "s");
+
+            var setPropertyMethod = typeof(SetPropertyCalls<TEntity>)
+                .GetMethods()
+                .First(m => m.Name == "SetProperty"
+                    && m.IsGenericMethodDefinition
+                    && m.GetParameters().Length == 2
+                    && m.GetParameters()[1].ParameterType.IsGenericType
+                    && m.GetParameters()[1].ParameterType.GetGenericTypeDefinition() == typeof(Func<,>))
+                .MakeGenericMethod(typeof(TProperty));
+
+            var setPropertyCall = Expression.Call(
+                sParam,
+                setPropertyMethod,
+                propSelector,
+                preparedExpr);
+
+            var setPropertyCallsExpr = Expression.Lambda<Func<SetPropertyCalls<TEntity>, SetPropertyCalls<TEntity>>>(
+                setPropertyCall, sParam);
+
             dbContext.Set<TEntity>().ExecuteUpdate(setPropertyCallsExpr);
+#endif
         }
 
         return SqlCaptureInterceptor.CapturedSql

--- a/src/LLL.AutoCompute.EFCore/LLL.AutoCompute.EFCore.csproj
+++ b/src/LLL.AutoCompute.EFCore/LLL.AutoCompute.EFCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -19,6 +19,11 @@
 
   <ItemGroup>
     <ProjectReference Include="..\LLL.AutoCompute\LLL.AutoCompute.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">

--- a/src/LLL.AutoCompute/LLL.AutoCompute.csproj
+++ b/src/LLL.AutoCompute/LLL.AutoCompute.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -17,12 +17,16 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/LLL.AutoCompute.EFCore.Tests/LLL.AutoCompute.EFCore.Tests.csproj
+++ b/test/LLL.AutoCompute.EFCore.Tests/LLL.AutoCompute.EFCore.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,6 +11,11 @@
 
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.Loader.UseRidGraph" Value="true" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
@@ -25,8 +30,8 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- Add `net10.0` target framework to all projects alongside existing `net8.0` and `net9.0`
- Add conditional package references for .NET 10 (EF Core 10.0.0, Extensions 10.0.0)
- Fix EF Core 10 breaking change: `SetPropertyCalls<T>` replaced by `UpdateSettersBuilder<T>` in `AutoComputeMigrationsModelDiffer`
- Update CI workflow to install .NET 8, 9, and 10 SDKs
- Update test packages: `Microsoft.NET.Test.Sdk` 18.3.0, `xunit` 2.9.3
- Normalize Microsoft.Extensions base versions to `x.0.0` in library projects

## Test plan
- [x] Build succeeds for all three target frameworks (net8.0, net9.0, net10.0)
- [x] All 99 tests pass on all three frameworks

🤖 Generated with [Claude Code](https://claude.com/claude-code)