### PR TITLE
Fix embedded file manifest generation for net8.0 and net9.0

### DIFF
--- a/LLL.AutoCompute.sln
+++ b/LLL.AutoCompute.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LLL.AutoCompute.EFCore.Test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LLL.AutoCompute.EFCore.Explorer", "src\LLL.AutoCompute.EFCore.Explorer\LLL.AutoCompute.EFCore.Explorer.csproj", "{382B6F6E-05AC-49B2-94FE-BC40D8E184CF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LLL.AutoCompute.EFCore.Explorer.Tests", "test\LLL.AutoCompute.EFCore.Explorer.Tests\LLL.AutoCompute.EFCore.Explorer.Tests.csproj", "{4F8EACF8-0A61-4E8C-946D-197C832875AE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -73,6 +75,18 @@ Global
 		{382B6F6E-05AC-49B2-94FE-BC40D8E184CF}.Release|x64.Build.0 = Release|Any CPU
 		{382B6F6E-05AC-49B2-94FE-BC40D8E184CF}.Release|x86.ActiveCfg = Release|Any CPU
 		{382B6F6E-05AC-49B2-94FE-BC40D8E184CF}.Release|x86.Build.0 = Release|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Debug|x64.Build.0 = Debug|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Debug|x86.Build.0 = Debug|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Release|x64.ActiveCfg = Release|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Release|x64.Build.0 = Release|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Release|x86.ActiveCfg = Release|Any CPU
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -82,5 +96,6 @@ Global
 		{D2897F60-D3D3-4091-BD99-504BB54B2FE2} = {A6A7E76B-2417-4FFB-8F6E-CB8EDDE4852C}
 		{13826017-F5D8-419F-AC91-451C4486685E} = {9E9F3AD0-78B2-44D0-9B91-3F760F613064}
 		{382B6F6E-05AC-49B2-94FE-BC40D8E184CF} = {A6A7E76B-2417-4FFB-8F6E-CB8EDDE4852C}
+		{4F8EACF8-0A61-4E8C-946D-197C832875AE} = {9E9F3AD0-78B2-44D0-9B91-3F760F613064}
 	EndGlobalSection
 EndGlobal

--- a/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
+++ b/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
@@ -16,10 +16,36 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.0" Condition="'$(TargetFramework)' == 'net10.0'" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="9.0.0" Condition="'$(TargetFramework)' == 'net9.0'" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="8.0.0" Condition="'$(TargetFramework)' == 'net8.0'" GeneratePathProperty="true" />
   </ItemGroup>
+
+  <!--
+    NuGet's framework reduction suppresses build assets (props/targets) from
+    Microsoft.Extensions.FileProviders.Embedded for TFMs where the assembly is
+    provided by the Microsoft.AspNetCore.App shared framework (the assets become _._).
+    This strips the manifest-generation MSBuild targets from those inner builds,
+    so GenerateEmbeddedFilesManifest silently produces no manifest XML.
+    Detect this via EmbeddedFilesManifestFileName (set by the package props) and
+    re-import the build props/targets explicitly for affected TFMs.
+
+    The .targets import happens in the project body (before SDK targets), so its
+    PrepareResourceNamesDependsOn modification gets overwritten by the SDK.
+    _EnsureManifestInputsCalculated bridges that gap by running before
+    AssignTargetPaths (a PrepareResourceNames dependency), ensuring the manifest
+    is added to EmbeddedResource before resource metadata is assigned.
+    See: https://github.com/dotnet/aspnetcore/issues/63719
+  -->
+  <Import Project="$(PkgMicrosoft_Extensions_FileProviders_Embedded)/build/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.props"
+          Condition="'$(TargetFramework)' != ''" />
+  <Import Project="$(PkgMicrosoft_Extensions_FileProviders_Embedded)/build/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.targets"
+          Condition="'$(TargetFramework)' != ''" />
+
+  <Target Name="_EnsureManifestInputsCalculated"
+          BeforeTargets="AssignTargetPaths"
+          DependsOnTargets="_CalculateEmbeddedFilesManifestInputs"
+          Condition="'$(TargetFramework)' != ''" />
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/test/LLL.AutoCompute.EFCore.Explorer.Tests/EmbeddedManifestTests.cs
+++ b/test/LLL.AutoCompute.EFCore.Explorer.Tests/EmbeddedManifestTests.cs
@@ -1,0 +1,29 @@
+using FluentAssertions;
+using Microsoft.Extensions.FileProviders;
+
+namespace LLL.AutoCompute.EFCore.Explorer.Tests;
+
+public class EmbeddedManifestTests
+{
+    [Fact]
+    public void Explorer_assembly_has_embedded_file_manifest()
+    {
+        var assembly = typeof(AutoComputeExplorerExtensions).Assembly;
+
+        var act = () => new ManifestEmbeddedFileProvider(assembly, "wwwroot");
+
+        act.Should().NotThrow(
+            "the NuGet package must include the embedded files manifest for all target frameworks");
+    }
+
+    [Fact]
+    public void Explorer_embedded_files_include_index_html()
+    {
+        var assembly = typeof(AutoComputeExplorerExtensions).Assembly;
+        var fileProvider = new ManifestEmbeddedFileProvider(assembly, "wwwroot");
+
+        var fileInfo = fileProvider.GetFileInfo("index.html");
+
+        fileInfo.Exists.Should().BeTrue("index.html must be embedded in the Explorer assembly");
+    }
+}

--- a/test/LLL.AutoCompute.EFCore.Explorer.Tests/GlobalUsings.cs
+++ b/test/LLL.AutoCompute.EFCore.Explorer.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/test/LLL.AutoCompute.EFCore.Explorer.Tests/LLL.AutoCompute.EFCore.Explorer.Tests.csproj
+++ b/test/LLL.AutoCompute.EFCore.Explorer.Tests/LLL.AutoCompute.EFCore.Explorer.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LLL.AutoCompute.EFCore.Explorer\LLL.AutoCompute.EFCore.Explorer.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

- **Fix**: `ManifestEmbeddedFileProvider` throws `InvalidOperationException` ("Could not load the embedded file manifest") when the Explorer NuGet package is consumed by projects targeting net8.0 or net9.0
- **Root cause**: NuGet's framework reduction replaces the package's build assets with `_._` for TFMs where the assembly is in the ASP.NET Core shared framework, silently stripping the manifest-generation MSBuild targets
- **Add**: Test project that verifies the manifest is correctly embedded for all target frameworks, preventing broken NuGet packages from being published

## How it works

The fix in `LLL.AutoCompute.EFCore.Explorer.csproj`:

1. **Explicit import** of the package's `build/netstandard2.0/` props and targets using `GeneratePathProperty` — bypasses NuGet's framework reduction
2. **Bridge target** (`_EnsureManifestInputsCalculated`) with `BeforeTargets="AssignTargetPaths"` — needed because the import happens in the project body (before SDK targets), so the SDK overwrites `PrepareResourceNamesDependsOn`; the bridge target re-hooks the manifest calculation using a target-level directive that can't be overwritten

Related upstream issue: https://github.com/dotnet/aspnetcore/issues/63719

## Test plan

- [x] `dotnet test` passes on all 3 TFMs (net8.0, net9.0, net10.0)
- [x] Manifest XML exists in `obj/Debug/net{8,9,10}.0/` after build
- [x] Manifest is embedded in the DLL for all TFMs
- [x] Tests fail when the fix is reverted (verified manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)