### PR TITLE
Fix MSB4011 duplicate import warning and patch CVE-2024-43483

### DIFF
--- a/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
+++ b/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
@@ -27,8 +27,8 @@
     provided by the Microsoft.AspNetCore.App shared framework (the assets become _._).
     This strips the manifest-generation MSBuild targets from those inner builds,
     so GenerateEmbeddedFilesManifest silently produces no manifest XML.
-    Detect this via EmbeddedFilesManifestFileName (set by the package props) and
-    re-import the build props/targets explicitly for affected TFMs.
+    Detect this via _FileProviderTaskAssembly (set by the package props) and
+    re-import the build props/targets explicitly only when NuGet skipped them.
 
     The .targets import happens in the project body (before SDK targets), so its
     PrepareResourceNamesDependsOn modification gets overwritten by the SDK.
@@ -37,10 +37,13 @@
     is added to EmbeddedResource before resource metadata is assigned.
     See: https://github.com/dotnet/aspnetcore/issues/63719
   -->
+  <PropertyGroup Condition="'$(TargetFramework)' != ''">
+    <_NeedsExplicitFileProviderImport Condition="'$(_FileProviderTaskAssembly)' == ''">true</_NeedsExplicitFileProviderImport>
+  </PropertyGroup>
   <Import Project="$(PkgMicrosoft_Extensions_FileProviders_Embedded)/build/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.props"
-          Condition="'$(TargetFramework)' != ''" />
+          Condition="'$(_NeedsExplicitFileProviderImport)' == 'true'" />
   <Import Project="$(PkgMicrosoft_Extensions_FileProviders_Embedded)/build/netstandard2.0/Microsoft.Extensions.FileProviders.Embedded.targets"
-          Condition="'$(TargetFramework)' != ''" />
+          Condition="'$(_NeedsExplicitFileProviderImport)' == 'true'" />
 
   <Target Name="_EnsureManifestInputsCalculated"
           BeforeTargets="AssignTargetPaths"

--- a/src/LLL.AutoCompute/LLL.AutoCompute.csproj
+++ b/src/LLL.AutoCompute/LLL.AutoCompute.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- **Fix MSB4011 warning**: The explicit `Import` of `Microsoft.Extensions.FileProviders.Embedded` props/targets was unconditional, causing duplicate-import warnings (MSB4011) on TFMs where NuGet already imports them (e.g. net10.0). Added a sentinel property (`_NeedsExplicitFileProviderImport`) that checks `_FileProviderTaskAssembly` before the imports, so they only run when NuGet's framework reduction suppressed them (net8.0, net9.0).
- **Bump `Microsoft.Extensions.Caching.Memory`** from 8.0.0 to 8.0.1 for the net8.0 TFM to address [CVE-2024-43483](https://github.com/advisories/GHSA-qj66-m88j-hmgj) (DoS via hash flooding).

## Test plan

- [x] `dotnet build` produces 0 MSB4011 warnings across all TFMs
- [x] `EmbeddedManifestTests` pass on net8.0, net9.0, and net10.0
- [x] No NU1903 vulnerability warnings remain