### PR TITLE
Suppress AD0001 RouteHandlerAnalyzer crash in Explorer

### DIFF
--- a/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
+++ b/src/LLL.AutoCompute.EFCore.Explorer/LLL.AutoCompute.EFCore.Explorer.csproj
@@ -8,6 +8,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
+    <!-- https://github.com/dotnet/aspnetcore/issues/56831 -->
+    <NoWarn>$(NoWarn);AD0001</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary

- Suppress `AD0001` warning in the Explorer project caused by a known bug in `RouteHandlerAnalyzer` when generics are used in minimal API endpoints.
- Tracked upstream: https://github.com/dotnet/aspnetcore/issues/56831
- The Explorer project doesn't use route handlers, so this analyzer provides no value here.

## Test plan

- [x] `dotnet build` produces 0 warnings for the Explorer project